### PR TITLE
Add type_name property, replace type with type_name in views

### DIFF
--- a/helsinki_notification/models.py
+++ b/helsinki_notification/models.py
@@ -95,3 +95,7 @@ class Notification(models.Model):
 
     def __str__(self):
         return self._localized_title
+
+    @property
+    def type_name(self) -> str:
+        return Notification.Type(self.type).name

--- a/helsinki_notification/views/rest_framework.py
+++ b/helsinki_notification/views/rest_framework.py
@@ -5,12 +5,14 @@ from helsinki_notification.models import Notification
 
 
 class NotificationSerializer(serializers.ModelSerializer):
+    type_name = serializers.SerializerMethodField()
+
     class Meta:
         model = Notification
         fields = [
             "id",
             "modified_at",
-            "type",
+            "type_name",
             "title_fi",
             "title_sv",
             "title_en",
@@ -24,6 +26,9 @@ class NotificationSerializer(serializers.ModelSerializer):
             "external_url_title_sv",
             "external_url_title_en",
         ]
+
+    def get_type_name(self, obj):
+        return obj.type_name
 
 
 class NotificationList(ListAPIView):

--- a/helsinki_notification/views/rest_framework.py
+++ b/helsinki_notification/views/rest_framework.py
@@ -32,5 +32,7 @@ class NotificationSerializer(serializers.ModelSerializer):
 
 
 class NotificationList(ListAPIView):
-    queryset = Notification.valid_objects.all()
     serializer_class = NotificationSerializer
+
+    def get_queryset(self):
+        return Notification.valid_objects.all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -100,3 +100,17 @@ def test_notification_default_ordering(valid_notification_factory, make_relative
         assert_qs_values(
             Notification.valid_objects.all(), expected_order, "id", ordered=True
         )
+
+
+@pytest.mark.parametrize(
+    "type_value, expected",
+    [
+        (Notification.Type.INFO, "INFO"),
+        (Notification.Type.ALERT, "ALERT"),
+        (Notification.Type.ERROR, "ERROR"),
+    ],
+)
+@pytest.mark.django_db
+def test_notification_type_name(valid_notification_factory, type_value, expected):
+    notification = valid_notification_factory(type=type_value)
+    assert notification.type_name == expected

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,31 +14,33 @@ def test_notification_model_managers(notification_factory, make_relative_time):
         datetime.fromisoformat("2025-01-01T12:00:00+00:00")
     )
     expired_notification = notification_factory(
+        title_en="Past notification, should NOT show up",
         validity_period_start=relative_time.last_hour,
         validity_period_end=relative_time.last_second,
     )
     future_notification = notification_factory(
+        title_en="Future notification, should NOT show up",
         validity_period_start=relative_time.next_second,
         validity_period_end=relative_time.tomorrow,
     )
     valid_notifications = [
-        # Middle of validity period
         notification_factory(
+            title_en="Middle of validity period",
             validity_period_start=relative_time.last_hour,
             validity_period_end=relative_time.next_hour,
         ),
-        # First valid second
         notification_factory(
+            title_en="First valid second",
             validity_period_start=relative_time.now,
             validity_period_end=relative_time.next_hour,
         ),
-        # Last valid second
         notification_factory(
+            title_en="Last valid second",
             validity_period_start=relative_time.last_hour,
             validity_period_end=relative_time.now,
         ),
-        # Valid only at 12:00:00
         notification_factory(
+            title_en="Valid only at 12:00:00",
             validity_period_start=relative_time.now,
             validity_period_end=relative_time.now,
         ),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -11,13 +11,13 @@ from tests.utils import values_list, values_list_from_dict
 def test_rest_framework_list_endpoint(
     notification_factory, valid_notification_factory, relative_now, client
 ):
-    # Past notification
     notification_factory(
+        title_en="Past notification",
         validity_period_start=relative_now.yesterday,
         validity_period_end=relative_now.last_second,
     )
-    # Future notification
     notification_factory(
+        title_en="Future notification",
         validity_period_start=relative_now.next_hour,
         validity_period_end=relative_now.far_future,
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,7 @@ import pytest
 from freezegun import freeze_time
 
 from helsinki_notification.models import Notification
+from helsinki_notification.views.rest_framework import NotificationSerializer
 from tests.utils import values_list, values_list_from_dict
 
 
@@ -33,3 +34,9 @@ def test_rest_framework_list_endpoint(
     assert values_list_from_dict(response.data, "id") == values_list(
         expected_order, "id"
     )
+
+
+def test_rest_framework_type_name_field(valid_notification_factory):
+    notification = valid_notification_factory.build(type=Notification.Type.INFO)
+    serializer = NotificationSerializer(instance=notification)
+    assert serializer.data["type_name"] == "INFO"


### PR DESCRIPTION
Makes the type representation a bit more user-friendly in views ("INFO", "ALERT" and "ERROR" instead of 20, 30 and 40)