### PR TITLE
feat: make the notification list url configurable

### DIFF
--- a/helsinki_notification/contrib/rest_framework/urls.py
+++ b/helsinki_notification/contrib/rest_framework/urls.py
@@ -1,9 +1,12 @@
 from django.urls import re_path
 
+from helsinki_notification import settings
 from helsinki_notification.contrib.rest_framework import views
+
+app_name = "helsinki_notification"
 
 urlpatterns = [
     re_path(
-        "^notifications/$", views.NotificationList.as_view(), name="notification-list"
+        settings.LIST_URL, views.NotificationList.as_view(), name="notification-list"
     )
 ]

--- a/helsinki_notification/settings.py
+++ b/helsinki_notification/settings.py
@@ -1,0 +1,6 @@
+from django.conf import settings as django_settings
+
+# URL for the list endpoint.
+LIST_URL = getattr(
+    django_settings, "HELSINKI_NOTIFICATION_LIST_URL", r"^notifications/$"
+)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,40 @@
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+import helsinki_notification.settings as app_settings
+
+
+@pytest.fixture
+def override_settings():
+    """NOTE: Do not set any URL-related setting with this in conjunction with anything
+    that resolves URLs (e.g. client requests, django.urls.reverse); resolved URLs are
+    cached and this will cause issues."""
+    from importlib import reload
+
+    import helsinki_notification.settings
+
+    @contextmanager
+    def _override(**options):
+        # Patch settings in django.conf rather than in helsinki_notification.settings;
+        # the latter gets reloaded later on which makes the module import the mocked
+        # version of django.conf.settings.
+        patcher = mock.patch("django.conf.settings")
+        mock_settings = patcher.start()
+        for k, v in options.items():
+            setattr(mock_settings, k, v)
+        reload(helsinki_notification.settings)
+
+        try:
+            yield
+        finally:
+            patcher.stop()
+            reload(helsinki_notification.settings)
+
+    return _override
+
+
+def test_list_url(override_settings):
+    with override_settings(HELSINKI_NOTIFICATION_LIST_URL="custom_list"):
+        assert app_settings.LIST_URL == "custom_list"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,5 +5,11 @@ import helsinki_notification.contrib.rest_framework.urls
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("drf/", include(helsinki_notification.contrib.rest_framework.urls)),
+    path(
+        "drf/",
+        include(
+            helsinki_notification.contrib.rest_framework.urls,
+            namespace="rest_framework",
+        ),
+    ),
 ]


### PR DESCRIPTION
Make the notification list URL configurable (via `HELSINKI_NOTIFICATION_LIST_URL` setting)