### PR TITLE
ci(release-please): exclude component name from tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        with:
+          include-component-in-tag: false


### PR DESCRIPTION
E.g. django-helsinki-notification-v0.1.0 becomes v0.1.0 instead.