### PR TITLE
feat(drf): serialize translation fields into translation maps 

### DIFF
--- a/helsinki_notification/constants.py
+++ b/helsinki_notification/constants.py
@@ -1,0 +1,1 @@
+LANGUAGES = ("fi", "sv", "en")

--- a/helsinki_notification/contrib/rest_framework/fields.py
+++ b/helsinki_notification/contrib/rest_framework/fields.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+from helsinki_notification.utils import map_translated_field
+
+
+class TranslatedField(serializers.Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value):
+        return map_translated_field(value, self.field_name)

--- a/helsinki_notification/contrib/rest_framework/views.py
+++ b/helsinki_notification/contrib/rest_framework/views.py
@@ -1,10 +1,15 @@
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView
 
+from helsinki_notification.contrib.rest_framework.fields import TranslatedField
 from helsinki_notification.models import Notification
 
 
 class NotificationSerializer(serializers.ModelSerializer):
+    content = TranslatedField()
+    external_url = TranslatedField()
+    external_url_title = TranslatedField()
+    title = TranslatedField()
     type_name = serializers.SerializerMethodField()
 
     class Meta:
@@ -13,18 +18,10 @@ class NotificationSerializer(serializers.ModelSerializer):
             "id",
             "modified_at",
             "type_name",
-            "title_fi",
-            "title_sv",
-            "title_en",
-            "content_fi",
-            "content_sv",
-            "content_en",
-            "external_url_fi",
-            "external_url_sv",
-            "external_url_en",
-            "external_url_title_fi",
-            "external_url_title_sv",
-            "external_url_title_en",
+            "title",
+            "content",
+            "external_url",
+            "external_url_title",
         ]
 
     def get_type_name(self, obj):

--- a/helsinki_notification/utils.py
+++ b/helsinki_notification/utils.py
@@ -1,0 +1,5 @@
+from helsinki_notification import constants
+
+
+def map_translated_field(instance, field_name, langs=constants.LANGUAGES):
+    return {lang: getattr(instance, f"{field_name}_{lang}") for lang in langs}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from django.utils import timezone
 from pytest_factoryboy import register
 
+from helsinki_notification import constants
 from tests.factories import NotificationFactory, ValidNotificationFactory
 
 register(NotificationFactory)
@@ -63,3 +64,8 @@ def make_relative_time():
         return RelativeTime(*args, **kwargs)
 
     return _make_relative_time
+
+
+@pytest.fixture
+def languages():
+    return constants.LANGUAGES

--- a/tests/contrib/test_rest_framework.py
+++ b/tests/contrib/test_rest_framework.py
@@ -40,3 +40,14 @@ def test_type_name_field(valid_notification_factory):
     notification = valid_notification_factory.build(type=Notification.Type.INFO)
     serializer = NotificationSerializer(instance=notification)
     assert serializer.data["type_name"] == "INFO"
+
+
+@pytest.mark.parametrize(
+    "field_name", ["title", "content", "external_url", "external_url_title"]
+)
+def test_translated_fields(field_name, notification_factory, languages):
+    fields = {f"{field_name}_{lang}": lang for lang in languages}
+    notification = notification_factory.build(**fields)
+    serializer = NotificationSerializer(instance=notification)
+    for lang in languages:
+        assert serializer.data[field_name][lang] == lang

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -9,6 +9,22 @@ from helsinki_notification.models import Notification
 
 @register
 class NotificationFactory(factory.django.DjangoModelFactory):
+    title_fi = factory.Faker("sentence", locale="fi_FI")
+    title_sv = factory.Faker("sentence", locale="sv_SE")
+    title_en = factory.Faker("sentence", locale="en_US")
+
+    external_url_fi = factory.Faker("url", locale="fi_FI")
+    external_url_sv = factory.Faker("url", locale="sv_SE")
+    external_url_en = factory.Faker("url", locale="en_US")
+
+    external_url_title_fi = factory.Faker("sentence", locale="fi_FI")
+    external_url_title_sv = factory.Faker("sentence", locale="sv_SE")
+    external_url_title_en = factory.Faker("sentence", locale="en_US")
+
+    content_fi = factory.Faker("text", locale="fi_FI")
+    content_sv = factory.Faker("text", locale="sv_SE")
+    content_en = factory.Faker("text", locale="en_US")
+
     class Meta:
         model = Notification
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import pytest
+
+from helsinki_notification.utils import map_translated_field
+
+
+def test_map_translated_field_returns_dict_of_translations(notification_factory):
+    notification = notification_factory.build()
+    assert map_translated_field(notification, "title") == {
+        "fi": notification.title_fi,
+        "sv": notification.title_sv,
+        "en": notification.title_en,
+    }
+
+
+def test_map_translated_field_raises_error_on_missing_field(notification_factory):
+    notification = notification_factory.build()
+    with pytest.raises(AttributeError):
+        map_translated_field(notification, "banana hammock")


### PR DESCRIPTION
Serialize translation fields into a map, e.g.
```
{
  "foo_fi": ...,
  "foo_sv": ...,
  "foo_en": ...
}
```

becomes:
```
{
  "foo": {
    "fi": ..., 
    "sv": ..., 
    "en": ...
  }
}
```